### PR TITLE
Import from aws-nitro-enclaves-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*/.*
+target
+**/*.rs.bk
+.idea
+*/debug
+*/release
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "eif_defs"
+version = "0.1.0"
+authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
+edition = "2018"
+license = "Apache-2.0"
+description = "This library provides the definition of the enclave image format (EIF) file used in AWS Nitro Enclaves."
+repository = "https://github.com/aws/aws-nitro-enclaves-image-format"
+readme = "README.md"
+keywords = ["Nitro", "Enclaves", "AWS"]
+
+[dependencies]
+sha2 = "0.9.5"
+serde = { version = ">=1.0", features = ["derive"] }
+serde_json = "1.0"
+num-traits = "0.2"
+num-derive = "0.3"
+byteorder = "1.3"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,6 @@
-## My Project
+## aws-nitro-enclaves-image-format
 
-TODO: Fill this README out!
-
-Be sure to:
-
-* Change the title in this README
-* Edit your repository description on GitHub
+This library provides the definition of the enclave image format (EIF) file.
 
 ## Security
 

--- a/src/eif_hasher.rs
+++ b/src/eif_hasher.rs
@@ -1,0 +1,343 @@
+// Copyright 2019-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![deny(warnings)]
+
+use sha2::Digest;
+use std::fmt::Debug;
+use std::io::Result as IoResult;
+use std::io::Write;
+use std::vec::Vec;
+
+use serde::{Deserialize, Serialize};
+
+/// EifHasher class
+///
+/// A simple serialization/deserialization friendly Hasher class.
+/// The only reason this exists is that we can't serialize a Hasher
+/// from sha2 crate, so we are going to use the following algorithm:
+///
+/// 1. Initialize digest with 0.
+/// 2. Gather block_size bytes in block field.
+/// 3. digest = Hash(Concatenate(digest, block))
+/// 4. Goto step 2
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EifHasher<T: Digest + Debug + Write + Clone> {
+    /// The bytes that have not been hashed yet, they get hashed
+    /// once we gather block_size bytes.
+    pub block: Vec<u8>,
+    /// Intermediary digest for the blocks processed untill now.
+    pub digest: Vec<u8>,
+    /// The number of bytes we need to gather before hashing, it needs to
+    /// be at least twice of the hasher output, since the hash of each output
+    /// is fed back into the hasher the size of the block impacts the performance
+    /// 0 means nothing is cached and all the bytes are feed to the hasher.
+    pub block_size: usize,
+    pub output_size: usize,
+    #[serde(skip)]
+    /// The hasher to be used, it is always in reset state, so we can skip
+    /// serialization.
+    pub hasher: T,
+}
+
+fn initial_digest(len: usize) -> Vec<u8> {
+    vec![0; len]
+}
+
+impl<T: Digest + Debug + Write + Clone> EifHasher<T> {
+    pub fn new(block_size: usize, mut hasher: T) -> Result<Self, String> {
+        let output_size = hasher.finalize_reset().len();
+        if block_size > 0 && output_size * 2 > block_size {
+            return Err("Invalid block_size".to_string());
+        }
+
+        Ok(EifHasher {
+            block: Vec::with_capacity(block_size),
+            digest: initial_digest(output_size),
+            block_size,
+            output_size,
+            hasher,
+        })
+    }
+
+    /// EifHasher constructor with fixed block size.
+    ///
+    /// It is needed in order for all clients of this class to use the same
+    /// block size if we want to get the same results.
+    pub fn new_with_fixed_block_size(hasher: T) -> Result<Self, String> {
+        /// This impacts the performance of the hasher, it is a sweet
+        /// spot where we get decent performance, 200MB/s, and where are not
+        /// forced to keep a large serialized state, 256 bytes for SHA256.
+        pub const FIXED_BLOCK_SIZE_HASHER_OUPUT_RATIO: usize = 8;
+        Self::new(
+            hasher.clone().finalize_reset().len() * FIXED_BLOCK_SIZE_HASHER_OUPUT_RATIO,
+            hasher,
+        )
+    }
+
+    /// EifHasher constructor without cache.
+    ///
+    /// EIfHasher acts like passthrough passing all the bytes to the actual hasher.
+    pub fn new_without_cache(hasher: T) -> Result<Self, String> {
+        Self::new(0, hasher)
+    }
+
+    pub fn finalize_reset(&mut self) -> IoResult<Vec<u8>> {
+        if self.block_size == 0 {
+            return Ok(self.hasher.finalize_reset().to_vec());
+        }
+        if !self.block.is_empty() {
+            self.consume_block()?;
+        }
+        let result = self.digest.clone();
+        self.digest = initial_digest(self.output_size);
+        Ok(result)
+    }
+
+    pub fn tpm_extend_finalize_reset(&mut self) -> IoResult<Vec<u8>> {
+        let result = self.finalize_reset()?;
+        let mut hasher = self.hasher.clone();
+
+        hasher.write_all(&initial_digest(self.output_size))?;
+        hasher.write_all(&result[..])?;
+        Ok(hasher.finalize_reset().to_vec())
+    }
+
+    fn consume_block(&mut self) -> IoResult<()> {
+        self.hasher.write_all(&self.digest[..])?;
+        self.hasher.write_all(&self.block[..])?;
+        self.block.clear();
+        let result = self.hasher.finalize_reset();
+        self.digest.copy_from_slice(&result[..]);
+        Ok(())
+    }
+}
+
+impl<T: Digest + Debug + Write + Clone> Write for EifHasher<T> {
+    fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+        if self.block_size == 0 {
+            self.hasher.write_all(buf)?;
+            return Ok(buf.len());
+        }
+        let mut remaining = buf;
+        while self.block.len() + remaining.len() >= self.block_size {
+            let (for_hasher, for_next_iter) =
+                remaining.split_at(self.block_size - self.block.len());
+            self.block.extend_from_slice(for_hasher);
+            self.consume_block()?;
+            remaining = for_next_iter;
+        }
+
+        self.block.extend_from_slice(remaining);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> IoResult<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EifHasher;
+    use crate::eif_hasher::initial_digest;
+    use sha2::{Digest, Sha256, Sha384, Sha512};
+    use std::fmt::Debug;
+    use std::io::Write;
+
+    const INPUT_BLOCK_SIZE_SHA256: usize = 64;
+    const INPUT_BLOCK_SIZE_SHA384: usize = 128;
+    const INPUT_BLOCK_SIZE_SHA512: usize = 128;
+
+    #[test]
+    fn invalid_block_size() {
+        let hasher = EifHasher::new(31, Sha256::new());
+        assert_eq!(hasher.is_err(), true);
+
+        let hasher = EifHasher::new(63, Sha512::new());
+        assert_eq!(hasher.is_err(), true);
+
+        let hasher = EifHasher::new(47, Sha384::new());
+        assert_eq!(hasher.is_err(), true)
+    }
+
+    #[test]
+    fn test_hash_less_values_than_block_size() {
+        hash_less_values_than_block_size(Sha256::new(), INPUT_BLOCK_SIZE_SHA256);
+        hash_less_values_than_block_size(Sha512::new(), INPUT_BLOCK_SIZE_SHA512);
+        hash_less_values_than_block_size(Sha384::new(), INPUT_BLOCK_SIZE_SHA384);
+    }
+
+    fn hash_less_values_than_block_size<T: Digest + Debug + Write + Clone>(
+        mut hasher_alg: T,
+        block_size: usize,
+    ) {
+        let data = vec![78u8; block_size - 1];
+        let output_size = hasher_alg.finalize_reset().len();
+        let mut hasher = EifHasher::new(block_size, hasher_alg.clone()).unwrap();
+
+        hasher.write_all(&data[..]).unwrap();
+        hasher_alg
+            .write_all(&initial_digest(output_size)[..])
+            .unwrap();
+        hasher_alg.write_all(&data[..]).unwrap();
+
+        let mut hasher_clone = hasher.clone();
+        let mut hasher_alg_clone = hasher_alg.clone();
+        assert_eq!(
+            hasher_alg.finalize_reset().to_vec(),
+            hasher.finalize_reset().unwrap()
+        );
+
+        let result = hasher_alg_clone.finalize_reset();
+        hasher_alg_clone
+            .write_all(&initial_digest(output_size)[..])
+            .unwrap();
+        hasher_alg_clone.write_all(&result[..]).unwrap();
+
+        assert_eq!(
+            hasher_clone.tpm_extend_finalize_reset().unwrap(),
+            hasher_alg_clone.finalize_reset().to_vec()
+        );
+    }
+
+    #[test]
+    fn test_hash_exact_block_size_values() {
+        hash_exact_block_size_values(Sha256::new(), INPUT_BLOCK_SIZE_SHA256);
+        hash_exact_block_size_values(Sha384::new(), INPUT_BLOCK_SIZE_SHA384);
+        hash_exact_block_size_values(Sha512::new(), INPUT_BLOCK_SIZE_SHA512);
+    }
+
+    fn hash_exact_block_size_values<T: Digest + Debug + Write + Clone>(
+        mut hasher_alg: T,
+        block_size: usize,
+    ) {
+        let data = vec![78u8; block_size];
+        let output_size = hasher_alg.finalize_reset().len();
+        let mut hasher = EifHasher::new(block_size, hasher_alg.clone()).unwrap();
+
+        hasher.write_all(&data).unwrap();
+        hasher_alg
+            .write_all(&initial_digest(output_size)[..])
+            .unwrap();
+        hasher_alg.write_all(&data[..block_size]).unwrap();
+
+        let mut hasher_clone = hasher.clone();
+        let mut hasher_alg_clone = hasher_alg.clone();
+
+        assert_eq!(
+            hasher_alg.finalize_reset().to_vec(),
+            hasher.finalize_reset().unwrap()
+        );
+
+        let result = hasher_alg_clone.finalize_reset();
+        hasher_alg_clone
+            .write_all(&initial_digest(output_size)[..])
+            .unwrap();
+        hasher_alg_clone.write_all(&result[..]).unwrap();
+
+        assert_eq!(
+            hasher_clone.tpm_extend_finalize_reset().unwrap(),
+            hasher_alg_clone.finalize_reset().to_vec()
+        );
+    }
+
+    #[test]
+    fn test_hash_more_values_than_block_size() {
+        hash_more_values_than_block_size(Sha256::new(), INPUT_BLOCK_SIZE_SHA256);
+        hash_more_values_than_block_size(Sha384::new(), INPUT_BLOCK_SIZE_SHA384);
+        hash_more_values_than_block_size(Sha512::new(), INPUT_BLOCK_SIZE_SHA512);
+    }
+
+    fn hash_more_values_than_block_size<T: Digest + Debug + Write + Clone>(
+        mut hasher_alg: T,
+        block_size: usize,
+    ) {
+        let data = vec![78u8; block_size + block_size / 2 - 1];
+        let output_size = hasher_alg.finalize_reset().len();
+        let (data1, data2) = data.split_at(block_size);
+        let mut hasher = EifHasher::new(block_size, hasher_alg.clone()).unwrap();
+
+        hasher.write_all(&data).unwrap();
+
+        hasher_alg.write_all(&initial_digest(output_size)).unwrap();
+        hasher_alg.write_all(data1).unwrap();
+        let result = hasher_alg.finalize_reset();
+        hasher_alg.write_all(&result).unwrap();
+        hasher_alg.write_all(data2).unwrap();
+
+        let mut hasher_clone = hasher.clone();
+        let mut hasher_alg_clone = hasher_alg.clone();
+
+        assert_eq!(
+            hasher_alg.finalize_reset().to_vec(),
+            hasher.finalize_reset().unwrap()
+        );
+
+        let result = hasher_alg_clone.finalize_reset();
+        hasher_alg_clone
+            .write_all(&initial_digest(output_size)[..])
+            .unwrap();
+        hasher_alg_clone.write_all(&result[..]).unwrap();
+
+        assert_eq!(
+            hasher_clone.tpm_extend_finalize_reset().unwrap(),
+            hasher_alg_clone.finalize_reset().to_vec()
+        );
+    }
+
+    #[test]
+    fn test_hash_with_writes_of_different_sizes() {
+        hash_with_writes_of_different_sizes(Sha256::new(), INPUT_BLOCK_SIZE_SHA256);
+        hash_with_writes_of_different_sizes(Sha384::new(), INPUT_BLOCK_SIZE_SHA512);
+        hash_with_writes_of_different_sizes(Sha512::new(), INPUT_BLOCK_SIZE_SHA512);
+    }
+
+    fn hash_with_writes_of_different_sizes<T: Digest + Debug + Write + Clone>(
+        hasher_alg: T,
+        block_size: usize,
+    ) {
+        let data = vec![78u8; block_size * 256];
+        let mut hasher_in_one_go = EifHasher::new(block_size, hasher_alg.clone()).unwrap();
+        let mut hasher_in_random_chunks = EifHasher::new(block_size, hasher_alg.clone()).unwrap();
+        let mut hasher_one_byte_at_atime = EifHasher::new(block_size, hasher_alg).unwrap();
+
+        hasher_in_one_go.write_all(&data).unwrap();
+        let mut remaining = &data[..];
+        let mut iteration = 1;
+        while !remaining.is_empty() {
+            let chunk_size = std::cmp::max(1, (iteration % remaining.len()) % block_size);
+            let (to_be_written, unhandled) = remaining.split_at(chunk_size);
+            hasher_in_random_chunks.write_all(to_be_written).unwrap();
+
+            remaining = unhandled;
+            iteration += 1987;
+        }
+
+        for x in data {
+            hasher_one_byte_at_atime.write_all(&[x]).unwrap();
+        }
+
+        let result1 = hasher_in_one_go.finalize_reset().unwrap();
+        let result2 = hasher_in_random_chunks.finalize_reset().unwrap();
+        let result3 = hasher_one_byte_at_atime.finalize_reset().unwrap();
+        assert_eq!(result1, result2);
+        assert_eq!(result1, result3);
+    }
+
+    #[test]
+    fn test_no_cache() {
+        let data = vec![78u8; 127 * 256];
+        let mut eif_hasher = EifHasher::new_without_cache(Sha384::new()).unwrap();
+        let mut hasher = Sha384::new();
+
+        hasher.write_all(&data[..]).unwrap();
+        for value in data {
+            eif_hasher.write(&[value]).unwrap();
+        }
+
+        let result1 = eif_hasher.finalize_reset().unwrap();
+        let result2 = hasher.finalize_reset();
+        assert_eq!(result1, result2.to_vec());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,384 @@
+// Copyright 2019-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![deny(warnings)]
+/// Definition Eif (Enclave Image format)
+///
+/// This crate is consumed by the following clients:
+///    - eif_utils: needed by the eif_builder.
+///    - eif_loader: needed to properly send an eif file over vsock.
+///
+/// With that in mind please be frugal with the dependencies for this
+/// crate.
+use byteorder::{BigEndian, ByteOrder};
+use num_derive::FromPrimitive;
+use num_traits::FromPrimitive;
+use serde::{Deserialize, Serialize};
+use std::mem::size_of;
+
+pub const EIF_MAGIC: [u8; 4] = [46, 101, 105, 102]; // .eif in ascii
+pub const MAX_NUM_SECTIONS: usize = 32;
+/// EIF Header Flags
+/// bits 1  : Architecture - toggled for aarch64, cleared for x86_64
+/// bits 2-8: Unused
+pub const EIF_HDR_ARCH_ARM64: u16 = 0x1;
+
+/// Current EIF version to be incremented every time we change the format
+/// of this structures, we assume changes are backwards compatible.
+/// V1 -> V2: Add support to generate and check CRC.
+/// V2 -> V3: Add the signature section.
+/// V3 -> V4: Add the metadata section.
+pub const CURRENT_VERSION: u16 = 4;
+
+#[derive(Clone, Copy, Debug)]
+pub struct EifHeader {
+    /// Magic number used to identify this file format
+    pub magic: [u8; 4],
+    /// EIF version
+    pub version: u16,
+    /// EIF header flags
+    pub flags: u16,
+    /// Default enclave memory used to boot this eif file
+    pub default_mem: u64,
+    /// Default enclave cpus number used to boot this eif file
+    pub default_cpus: u64,
+    pub reserved: u16,
+    pub num_sections: u16,
+    pub section_offsets: [u64; MAX_NUM_SECTIONS],
+    /// Sizes for each section, we need this information in the
+    /// header because the vsock_loader needs to know how large are the
+    /// ramdisks
+    pub section_sizes: [u64; MAX_NUM_SECTIONS],
+    pub unused: u32,
+    /// crc32 IEEE used for validating the eif file is correct, it contains
+    /// the crc for everything except the bytes representing this field.
+    /// Needs to be the last field of the header.
+    pub eif_crc32: u32,
+}
+
+impl EifHeader {
+    pub fn from_be_bytes(bytes: &[u8]) -> Result<Self, String> {
+        let mut pos = 0;
+
+        let mut magic = [0u8; 4];
+        magic.copy_from_slice(&bytes[pos..pos + size_of::<[u8; 4]>()]);
+        pos += size_of::<[u8; 4]>();
+
+        let version = BigEndian::read_u16(&bytes[pos..]);
+        pos += size_of::<u16>();
+        let flags = BigEndian::read_u16(&bytes[pos..]);
+        pos += size_of::<u16>();
+        let default_mem = BigEndian::read_u64(&bytes[pos..]);
+        pos += size_of::<u64>();
+        let default_cpus = BigEndian::read_u64(&bytes[pos..]);
+        pos += size_of::<u64>();
+        let reserved = BigEndian::read_u16(&bytes[pos..]);
+        pos += size_of::<u16>();
+        let num_sections = BigEndian::read_u16(&bytes[pos..]);
+        pos += size_of::<u16>();
+
+        let mut section_offsets = [0u64; MAX_NUM_SECTIONS];
+        for item in section_offsets.iter_mut() {
+            *item = BigEndian::read_u64(&bytes[pos..]);
+            pos += size_of::<u64>();
+        }
+
+        let mut section_sizes = [0u64; MAX_NUM_SECTIONS];
+        for item in section_sizes.iter_mut() {
+            *item = BigEndian::read_u64(&bytes[pos..]);
+            pos += size_of::<u64>();
+        }
+
+        let unused = BigEndian::read_u32(&bytes[pos..]);
+        pos += size_of::<u32>();
+        let eif_crc32 = BigEndian::read_u32(&bytes[pos..]);
+        pos += size_of::<u32>();
+
+        if bytes.len() != pos {
+            return Err("Invalid EifHeader length".to_string());
+        }
+
+        Ok(EifHeader {
+            magic,
+            version,
+            flags,
+            default_mem,
+            default_cpus,
+            reserved,
+            num_sections,
+            section_offsets,
+            section_sizes,
+            unused,
+            eif_crc32,
+        })
+    }
+
+    pub fn to_be_bytes(&self) -> Vec<u8> {
+        let mut buf = [0u8; Self::size()];
+        let mut result = Vec::new();
+        let mut pos = 0;
+
+        buf[pos..pos + size_of::<[u8; 4]>()].copy_from_slice(&self.magic);
+        pos += size_of::<[u8; 4]>();
+
+        BigEndian::write_u16(&mut buf[pos..], self.version);
+        pos += size_of::<u16>();
+        BigEndian::write_u16(&mut buf[pos..], self.flags);
+        pos += size_of::<u16>();
+        BigEndian::write_u64(&mut buf[pos..], self.default_mem);
+        pos += size_of::<u64>();
+        BigEndian::write_u64(&mut buf[pos..], self.default_cpus);
+        pos += size_of::<u64>();
+        BigEndian::write_u16(&mut buf[pos..], self.reserved);
+        pos += size_of::<u16>();
+        BigEndian::write_u16(&mut buf[pos..], self.num_sections);
+        pos += size_of::<u16>();
+
+        for elem in self.section_offsets.iter() {
+            BigEndian::write_u64(&mut buf[pos..], *elem);
+            pos += size_of::<u64>();
+        }
+
+        for elem in self.section_sizes.iter() {
+            BigEndian::write_u64(&mut buf[pos..], *elem);
+            pos += size_of::<u64>();
+        }
+
+        BigEndian::write_u32(&mut buf[pos..], self.unused);
+        pos += size_of::<u32>();
+        BigEndian::write_u32(&mut buf[pos..], self.eif_crc32);
+
+        result.extend_from_slice(&buf[..]);
+        result
+    }
+
+    pub const fn size() -> usize {
+        4 * size_of::<u16>()
+            + 2 * size_of::<u32>()
+            + 2 * size_of::<u64>()
+            + size_of::<[u8; 4]>()
+            + 2 * size_of::<[u64; MAX_NUM_SECTIONS]>()
+    }
+}
+
+#[derive(Clone, Copy, Debug, FromPrimitive, PartialEq)]
+#[repr(u16)]
+pub enum EifSectionType {
+    EifSectionInvalid,
+    EifSectionKernel,
+    EifSectionCmdline,
+    EifSectionRamdisk,
+    EifSectionSignature,
+    EifSectionMetadata,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct EifSectionHeader {
+    pub section_type: EifSectionType,
+    pub flags: u16,
+    pub section_size: u64,
+}
+
+impl EifSectionHeader {
+    pub fn from_be_bytes(bytes: &[u8]) -> Result<Self, String> {
+        let mut pos = 0;
+
+        let section_type = BigEndian::read_u16(&bytes[pos..]);
+        pos += size_of::<u16>();
+        let flags = BigEndian::read_u16(&bytes[pos..]);
+        pos += size_of::<u16>();
+        let section_size = BigEndian::read_u64(&bytes[pos..]);
+        pos += size_of::<u64>();
+
+        if bytes.len() != pos {
+            return Err("Invalid EifSectionHeader length".to_string());
+        }
+
+        Ok(EifSectionHeader {
+            section_type: FromPrimitive::from_u16(section_type)
+                .ok_or_else(|| "Invalid section type".to_string())?,
+            flags,
+            section_size,
+        })
+    }
+
+    pub fn to_be_bytes(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        let mut buf = [0u8; Self::size()];
+        let mut pos = 0;
+
+        BigEndian::write_u16(&mut buf[pos..], self.section_type as u16);
+        pos += size_of::<u16>();
+        BigEndian::write_u16(&mut buf[pos..], self.flags);
+        pos += size_of::<u16>();
+        BigEndian::write_u64(&mut buf[pos..], self.section_size);
+
+        result.extend_from_slice(&buf[..]);
+        result
+    }
+
+    pub const fn size() -> usize {
+        size_of::<EifSectionType>() + size_of::<u16>() + size_of::<u64>()
+    }
+}
+
+/// Array containing the signatures of at least one PCR.
+/// For now, it only contains the signature of PRC0.
+pub type EifSignature = Vec<PcrSignature>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PcrSignature {
+    /// The PEM-formatted signing certificate
+    pub signing_certificate: Vec<u8>,
+    /// The serialized COSESign1 object generated using the byte array
+    /// formed from RegisterIndex and RegisterValue as payload
+    pub signature: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PcrInfo {
+    /// The index of the PCR
+    pub register_index: i32,
+    /// The value of the PCR
+    pub register_value: Vec<u8>,
+}
+
+impl PcrInfo {
+    pub fn new(register_index: i32, register_value: Vec<u8>) -> Self {
+        PcrInfo {
+            register_index,
+            register_value,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EifBuildInfo {
+    #[serde(rename = "BuildTime")]
+    pub build_time: String,
+    #[serde(rename = "BuildTool")]
+    pub build_tool: String,
+    #[serde(rename = "BuildToolVersion")]
+    pub build_tool_version: String,
+    #[serde(rename = "OperatingSystem")]
+    pub img_os: String,
+    #[serde(rename = "KernelVersion")]
+    pub img_kernel: String,
+}
+
+/// Structure used for (de)serializing metadata when
+/// writing or reading the metadata section of the EIF
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EifIdentityInfo {
+    #[serde(rename = "ImageName")]
+    pub img_name: String,
+    #[serde(rename = "ImageVersion")]
+    pub img_version: String,
+    #[serde(rename = "BuildMetadata")]
+    pub build_info: EifBuildInfo,
+    #[serde(rename = "DockerInfo")]
+    pub docker_info: serde_json::Value,
+    #[serde(rename = "CustomMetadata")]
+    pub custom_info: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{EifHeader, EifSectionHeader, EifSectionType};
+    use crate::{EIF_MAGIC, MAX_NUM_SECTIONS};
+
+    #[test]
+    fn test_eif_section_type() {
+        assert_eq!(std::mem::size_of::<EifSectionType>(), 2);
+    }
+
+    #[test]
+    fn test_eif_section_header_to_from_be_bytes() {
+        let eif_section_header = EifSectionHeader {
+            section_type: EifSectionType::EifSectionSignature,
+            flags: 3,
+            section_size: 123,
+        };
+
+        let bytes = eif_section_header.to_be_bytes();
+        assert_eq!(bytes.len(), EifSectionHeader::size());
+
+        let new_eif_section_header = EifSectionHeader::from_be_bytes(&bytes).unwrap();
+        assert_eq!(
+            eif_section_header.section_type,
+            new_eif_section_header.section_type
+        );
+        assert_eq!(eif_section_header.flags, new_eif_section_header.flags);
+        assert_eq!(
+            eif_section_header.section_size,
+            new_eif_section_header.section_size
+        );
+    }
+
+    #[test]
+    fn test_eif_header_to_from_be_bytes() {
+        let eif_header = EifHeader {
+            magic: EIF_MAGIC,
+            version: 3,
+            flags: 4,
+            default_mem: 5,
+            default_cpus: 6,
+            reserved: 2,
+            num_sections: 5,
+            section_offsets: [12u64; MAX_NUM_SECTIONS],
+            section_sizes: [13u64; MAX_NUM_SECTIONS],
+            unused: 0,
+            eif_crc32: 123,
+        };
+
+        let bytes = eif_header.to_be_bytes();
+        assert_eq!(bytes.len(), EifHeader::size());
+
+        let new_eif_header = EifHeader::from_be_bytes(&bytes).unwrap();
+        assert_eq!(eif_header.magic, new_eif_header.magic);
+        assert_eq!(eif_header.version, new_eif_header.version);
+        assert_eq!(eif_header.flags, new_eif_header.flags);
+        assert_eq!(eif_header.default_mem, new_eif_header.default_mem);
+        assert_eq!(eif_header.default_cpus, new_eif_header.default_cpus);
+        assert_eq!(eif_header.reserved, new_eif_header.reserved);
+        assert_eq!(eif_header.num_sections, new_eif_header.num_sections);
+        assert_eq!(eif_header.section_offsets, new_eif_header.section_offsets);
+        assert_eq!(eif_header.section_sizes, new_eif_header.section_sizes);
+        assert_eq!(eif_header.unused, new_eif_header.unused);
+        assert_eq!(eif_header.eif_crc32, new_eif_header.eif_crc32);
+    }
+
+    #[test]
+    fn test_eif_header_size() {
+        assert_eq!(EifHeader::size(), 548);
+    }
+
+    #[test]
+    fn test_eif_section_header_size() {
+        assert_eq!(EifSectionHeader::size(), 12);
+    }
+
+    #[test]
+    fn test_eif_header_from_be_bytes_invalid_length() {
+        let bytes = [0u8; 550];
+        assert!(EifHeader::from_be_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_eif_section_header_from_be_bytes_invalid_length() {
+        let bytes = [0u8; 16];
+        assert!(EifSectionHeader::from_be_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_eif_section_header_from_be_bytes_invalid_section_type() {
+        let mut bytes = [0u8; 12];
+        // As there are 6 EIF section types, set the enum index to 6
+        // so we get an invalid section to cause the error.
+        bytes[1] = 6;
+
+        assert_eq!(EifSectionHeader::from_be_bytes(&bytes).is_err(), true);
+    }
+}
+
+pub mod eif_hasher;


### PR DESCRIPTION
... from source code at
https://github.com/aws/aws-nitro-enclaves-cli/releases/tag/v1.2.0

Signed-off-by: Sabin Rapan <sabrapan@amazon.com>

*Description of changes:*

This allows both aws-nitro-enclaves-cli and other consumers to depend on a single source of truth for the APIs that define an EIF.

```shell
$ diff -u ../aws-nitro-enclaves-cli/eif_defs/src/eif_hasher.rs src/eif_hasher.rs
--- ../aws-nitro-enclaves-cli/eif_defs/src/eif_hasher.rs        2022-04-23 11:50:42.956474695 +0000
+++ src/eif_hasher.rs   2022-04-23 11:20:57.938533666 +0000
@@ -1,4 +1,4 @@
-// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0

 #![deny(warnings)]
```

```shell
$ diff -u ../aws-nitro-enclaves-cli/eif_defs/src/lib.rs src/lib.rs
--- ../aws-nitro-enclaves-cli/eif_defs/src/lib.rs       2022-04-23 11:50:42.956474695 +0000
+++ src/lib.rs  2022-04-23 11:51:36.244900424 +0000
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// Copyright 2019-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0

 #![deny(warnings)]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
