### PR TITLE
Kms image signing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ byteorder = "1.3"
 clap = "3.2"
 hex = "0.4"
 crc = "1.8"
-aws-nitro-enclaves-cose = "0.5"
+aws-nitro-enclaves-cose = { version = "0.5", features = ["key_kms"] }
 openssl = "0.10"
 serde_cbor = "0.11"
 chrono = { version = "0.4", default-features = false, features = ["clock"]}
+aws-sdk-kms = "0.24"
+aws-config = "0.54.0"
+tokio = { version = "1.20", features = ["rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ chrono = { version = "0.4", default-features = false, features = ["clock"]}
 aws-sdk-kms = "0.24"
 aws-config = "0.54.0"
 tokio = { version = "1.20", features = ["rt-multi-thread"] }
+xmlparser = "0.13.5"

--- a/examples/eif_build.rs
+++ b/examples/eif_build.rs
@@ -18,7 +18,7 @@ use aws_nitro_enclaves_image_format::defs::EifIdentityInfo;
 use aws_nitro_enclaves_image_format::utils::identity::parse_custom_metadata;
 use aws_nitro_enclaves_image_format::{
     generate_build_info,
-    utils::{get_pcrs, EifBuilder, SignEnclaveInfo, eif_signer::SigningKey},
+    utils::{eif_signer::SigningKey, get_pcrs, EifBuilder, SignEnclaveInfo},
 };
 use clap::{App, Arg};
 use serde_json::json;
@@ -171,20 +171,34 @@ fn main() {
             if signing_certificate.is_none() {
                 panic!("Both signing-certificate and private-key parameters must be provided")
             }
-            Some(SignEnclaveInfo::new(signing_certificate.unwrap(), &SigningKey::LocalKey{
-                path: key_path.to_string()
-            }).expect("Could not read signing info"))
-        },
+            Some(
+                SignEnclaveInfo::new(
+                    signing_certificate.unwrap(),
+                    &SigningKey::LocalKey {
+                        path: key_path.to_string(),
+                    },
+                )
+                .expect("Could not read signing info"),
+            )
+        }
         (Some(kms_arn), None) => {
             if signing_certificate.is_none() {
                 panic!("Both signing-certificate and kms-key-arn parameters must be provided")
             }
-            Some(SignEnclaveInfo::new(signing_certificate.unwrap(), &SigningKey::KmsKey{
-                arn: kms_arn.to_string(),
-                region: kms_key_region.unwrap().to_string()
-            }).expect("Could not read signing info"))
-        },
-        (Some(_), Some(_)) => panic!("Both signing-certificate and private-key parameters must be provided"),
+            Some(
+                SignEnclaveInfo::new(
+                    signing_certificate.unwrap(),
+                    &SigningKey::KmsKey {
+                        arn: kms_arn.to_string(),
+                        region: kms_key_region.unwrap().to_string(),
+                    },
+                )
+                .expect("Could not read signing info"),
+            )
+        }
+        (Some(_), Some(_)) => {
+            panic!("Both signing-certificate and private-key parameters must be provided")
+        }
     };
 
     let img_name = matches.value_of("image_name").map(|val| val.to_string());

--- a/src/utils/eif_reader.rs
+++ b/src/utils/eif_reader.rs
@@ -5,9 +5,7 @@ use crate::defs::eif_hasher::EifHasher;
 use crate::defs::{
     EifHeader, EifIdentityInfo, EifSectionHeader, EifSectionType, PcrInfo, PcrSignature,
 };
-use aws_nitro_enclaves_cose::{
-    crypto::Openssl, CoseSign1,
-};
+use aws_nitro_enclaves_cose::{crypto::Openssl, CoseSign1};
 use crc::{crc32, Hasher32};
 use openssl::pkey::PKey;
 use serde::{Deserialize, Serialize};

--- a/src/utils/eif_reader.rs
+++ b/src/utils/eif_reader.rs
@@ -5,7 +5,9 @@ use crate::defs::eif_hasher::EifHasher;
 use crate::defs::{
     EifHeader, EifIdentityInfo, EifSectionHeader, EifSectionType, PcrInfo, PcrSignature,
 };
-use aws_nitro_enclaves_cose::{crypto::Openssl, CoseSign1};
+use aws_nitro_enclaves_cose::{
+    crypto::kms::KmsKey, crypto::Openssl, crypto::SignatureAlgorithm, CoseSign1,
+};
 use crc::{crc32, Hasher32};
 use openssl::pkey::PKey;
 use serde::{Deserialize, Serialize};
@@ -16,6 +18,9 @@ use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
+
+use aws_sdk_kms::{client::Client, Region};
+use tokio::runtime::Runtime;
 
 /// The information about the signing certificate to be provided for a `describe-eif` request.
 #[derive(Clone, Serialize, Deserialize)]
@@ -226,6 +231,8 @@ impl EifReader {
     pub fn get_certificate_info(
         &mut self,
         measurements: BTreeMap<String, String>,
+        region: Option<String>,
+        key_id: Option<String>,
     ) -> Result<SignCertificateInfo, String> {
         let signature_buf = match &self.signature_section {
             Some(section) => section,
@@ -266,25 +273,53 @@ impl EifReader {
         let measured_payload =
             to_vec(&pcr_info).map_err(|e| format!("Could not serialize PCR info: {:?}", e))?;
 
-        // Extract public key from certificate and convert to PKey
-        let public_key = &cert
-            .public_key()
-            .map_err(|e| format!("Failed to get public key: {:?}", e))?;
-        let coses_key = PKey::public_key_from_pem(
-            &public_key
-                .public_key_to_pem()
-                .map_err(|e| format!("Failed to serialize public key: {:?}", e))?[..],
-        )
-        .map_err(|e| format!("Failed to decode key nit elliptic key structure: {:?}", e))?;
-
         // Deserialize COSE signature and extract the payload using the public key
         let pcr_sign = CoseSign1::from_bytes(&des_sign[0].signature[..])
             .map_err(|e| format!("Failed to deserialize signature: {:?}", e))?;
-        let coses_payload = pcr_sign
-            .get_payload::<Openssl>(Some(coses_key.as_ref()))
-            .map_err(|e| format!("Failed to get signature payload: {:?}", e))?;
 
-        self.sign_check = Some(measured_payload == coses_payload);
+        match (&region, &key_id) {
+            (Some(_), Some(_)) => {
+                // Get KMS key using provided region and id
+                let mut coses_key = None;
+                let act = async {
+                    let shared_config = aws_config::from_env()
+                        .region(region.map(Region::new).unwrap())
+                        .load()
+                        .await;
+                    let client = Client::new(&shared_config);
+                    coses_key = Some(
+                        KmsKey::new(client, key_id.unwrap(), SignatureAlgorithm::ES384)
+                            .expect("Failed to get kms key"),
+                    );
+                };
+                let runtime = Runtime::new().unwrap();
+                runtime.block_on(act);
+
+                let coses_payload = pcr_sign
+                    .get_payload::<Openssl>(Some(&coses_key.unwrap()))
+                    .map_err(|e| format!("Failed to get signature payload: {:?}", e))?;
+
+                self.sign_check = Some(measured_payload == coses_payload);
+            }
+            (None, None) => {
+                // Extract public key from certificate and convert to PKey
+                let public_key = &cert
+                    .public_key()
+                    .map_err(|e| format!("Failed to get public key: {:?}", e))?;
+                let coses_key = PKey::public_key_from_pem(
+                    &public_key
+                        .public_key_to_pem()
+                        .map_err(|e| format!("Failed to serialize public key: {:?}", e))?[..],
+                )
+                .map_err(|e| format!("Failed to decode key nit elliptic key structure: {:?}", e))?;
+                let coses_payload = pcr_sign
+                    .get_payload::<Openssl>(Some(coses_key.as_ref()))
+                    .map_err(|e| format!("Failed to get signature payload: {:?}", e))?;
+
+                self.sign_check = Some(measured_payload == coses_payload);
+            }
+            _ => (),
+        }
 
         Ok(SignCertificateInfo {
             issuer_name,

--- a/src/utils/eif_signer.rs
+++ b/src/utils/eif_signer.rs
@@ -1,0 +1,256 @@
+use aws_sdk_kms::{Region, client::Client};
+use aws_nitro_enclaves_cose::{
+    CoseSign1, header_map::HeaderMap, 
+    crypto::kms::KmsKey, crypto::SignatureAlgorithm, crypto::Openssl
+};
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::{Read, Seek, SeekFrom, Write};
+use tokio::runtime::Runtime;
+use openssl::pkey::PKey;
+use sha2::{Digest, Sha384};
+
+use crate::utils::eif_reader::EifReader;
+use crate::utils::get_pcrs;
+
+use serde_cbor::to_vec;
+
+use crate::defs::{
+    EifSectionHeader,EifSectionType,PcrSignature,PcrInfo,
+    EifHeader
+};
+
+#[derive(Debug, PartialEq)]
+pub enum SigningMethod {
+    PKey,
+    Kms,
+    NoSign,
+}
+
+/// Used for signing enclave image file
+pub struct EifSigner {
+    /// EIF file path.
+    pub eif_path: String,
+    /// Method used to sign the enclave image. (PrivateKey or KMS)
+    pub signing_method: SigningMethod,
+    /// Certificate file path
+    pub signing_certificate: Vec<u8>,
+    /// Private key
+    pub private_key: Option<Vec<u8>>,
+    /// KMS key
+    pub kms_key: Option<KmsKey>,
+    /// Is signed
+    pub is_signed: bool,
+}
+
+impl EifSigner {
+    pub fn new(
+        eif_path: String,
+        signing_method: String,
+        cert_path: String,
+        key_path: Option<String>,
+        region: Option<String>,
+        key_id: Option<String>,
+    ) -> Result<Self, String> {
+        let mut method = SigningMethod::NoSign;
+        let mut private_key = Vec::new();
+        let mut kms_key = None;
+
+        let mut certificate_file = File::open(cert_path)
+            .map_err(|err| format!("Could not open the certificate file: {:?}", err))?;
+        let mut signing_certificate = Vec::new();
+        certificate_file
+            .read_to_end(&mut signing_certificate)
+            .map_err(|err| format!("Could not read the certificate file: {:?}", err))?;
+
+        match signing_method.as_str() {
+            "PrivateKey" => {
+                method = SigningMethod::PKey;
+                let key_path = key_path.as_ref().map(String::as_str).unwrap();
+
+                let mut key_file = File::open(key_path)
+                    .map_err(|err| format!("Could not open the key file: {:?}", err))?;
+                key_file
+                    .read_to_end(&mut private_key)
+                    .map_err(|err| format!("Could not read the key file: {:?}", err))?;
+            }
+            "KMS" => {
+                method = SigningMethod::Kms;
+                let act = async {
+                    let shared_config = aws_config::from_env().region(region.map(Region::new).unwrap()).load().await;
+                    let client = Client::new(&shared_config);
+                    kms_key = Some(KmsKey::new(
+                        client,
+                        key_id.unwrap(),
+                        SignatureAlgorithm::ES384,
+                    ).expect("Error building kms_key"));
+                };
+                let runtime = Runtime::new().unwrap();
+                runtime.block_on(act);
+            }
+            _ => ()
+        };
+
+        let eif_reader = EifReader::from_eif(eif_path.clone())
+            .map_err(|err| format!("Could not read the EIF: {:?}", err))?;
+
+        Ok(EifSigner {
+            eif_path: eif_path,
+            signing_method: method,
+            signing_certificate: signing_certificate,
+            private_key: Some(private_key),
+            kms_key: kms_key,
+            is_signed: eif_reader.signature_section.is_some(),
+        })
+    } 
+
+    /// Get the pcr information that will be used as payload, from the
+    /// existing enclave image file.
+    pub fn get_payload(&mut self) -> Result<Vec<u8>, String> {
+        let mut eif_reader = EifReader::from_eif(self.eif_path.clone())
+            .map_err(|err| format!("Could not read the EIF: {:?}", err))?;
+        let measurements = get_pcrs(
+            &mut eif_reader.image_hasher,
+            &mut eif_reader.bootstrap_hasher,
+            &mut eif_reader.app_hasher,
+            &mut eif_reader.cert_hasher,
+            Sha384::new(),
+            eif_reader.signature_section.is_some(),
+        ).expect("Failed to get measurements");
+
+        let pcr0 = match measurements.get("PCR0") {
+            Some(pcr) => pcr,
+            None => ""
+        };
+
+        let pcr_info = PcrInfo::new(
+            0,
+            hex::decode(pcr0).map_err(|e| format!("Error while decoding PCR0: {:?}", e))?,
+        );
+
+        let payload = to_vec(&pcr_info).expect("Could not serialize PCR info");
+
+        Ok(payload)
+    }
+
+    /// Writes the provided pcr signature to an existing EIF
+    pub fn write_signature(&mut self, pcr_signature: PcrSignature) -> Result<(), String> {
+        let mut eif_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&self.eif_path)
+            .unwrap();
+
+        let eif_signature = vec![pcr_signature];
+        let serialized_signature =
+            to_vec(&eif_signature).expect("Could not serialize the signature");
+        let signature_size = serialized_signature.len() as u64;
+        
+        let eif_section = EifSectionHeader {
+            section_type: EifSectionType::EifSectionSignature,
+            flags: 0,
+            section_size: signature_size,
+        };
+
+        let mut curr_seek = 0;
+
+        // If the file is already signed, replace the existing signature
+        if self.is_signed {
+            let mut eif_content = Vec::<Vec<u8>>::new();
+            let mut header_buf = vec![0u8; EifHeader::size()];
+            let mut section_buf = vec![0u8; EifSectionHeader::size()];
+
+            eif_file
+                .read_exact(&mut header_buf)
+                .map_err(|e| format!("Error while reading EIF header: {:?}", e))?;
+            eif_content.push(header_buf.clone());
+
+            curr_seek += EifHeader::size();
+            eif_file
+                .seek(SeekFrom::Start(curr_seek as u64))
+                .map_err(|e| format!("Failed to seek file from start: {:?}", e))?;
+            while eif_file
+                .read_exact(&mut section_buf)
+                .map_err(|e| format!("Error while reading EIF header: {:?}", e))
+                .is_ok()
+            {
+                let section = EifSectionHeader::from_be_bytes(&section_buf)
+                    .map_err(|e| format!("Error extracting EIF section header: {:?}", e))?;
+                
+                if section.section_type == EifSectionType::EifSectionSignature {
+                    eif_content.push(serialized_signature.clone().to_vec());
+                }
+
+                eif_content.push(section_buf.clone());
+                curr_seek += EifSectionHeader::size();
+                curr_seek += section.section_size as usize;
+                eif_file
+                    .seek(SeekFrom::Start(curr_seek as u64))
+                    .map_err(|e| format!("Failed to seek after EIF section: {:?}", e))?;
+            }
+            eif_file
+                .seek(SeekFrom::Start(0))
+                .map_err(|e| format!("Error while truncating EIF: {:?}", e))?;
+            for section in eif_content {
+                eif_file
+                    .write_all(&section)
+                    .map_err(|e| format!("Error while writing EIF: {:?}", e))?;
+            }
+        } else {
+            // Create the signature section for an EIF that is not signed
+            let eif_buffer = eif_section.to_be_bytes();
+
+            eif_file
+                .seek(SeekFrom::End(0))
+                .map_err(|e| format!("Failed to seek file from end: {:?}", e))?;
+            eif_file
+                .write_all(&eif_buffer[..])
+                .expect("Failed to write signature header");
+            eif_file
+                .write_all(&serialized_signature[..])
+                .expect("Failed write signature");
+        }
+
+        Ok(())
+    }
+
+    /// Generates the signature based on the selected method and writes it to the EIF
+    pub fn sign_image(&mut self) -> Result<(), String> {
+        if self.signing_method == SigningMethod::NoSign {
+            return Ok(());
+        }
+
+        let mut signature = Vec::new();
+        let payload = self.get_payload()
+            .expect("Failed to get payload for image signing.");
+
+        match &self.signing_method {
+            SigningMethod::PKey =>{
+                let private_key = PKey::private_key_from_pem(&mut self.private_key.as_ref().unwrap())
+                    .expect("Could not deserialize the PEM-formatted private key");
+        
+                signature = CoseSign1::new::<Openssl>(&payload, &HeaderMap::new(), private_key.as_ref())
+                    .unwrap()
+                    .as_bytes(false)
+                    .unwrap();        
+            },
+            SigningMethod::Kms => {
+                signature = CoseSign1::new::<Openssl>(&payload, &HeaderMap::new(), self.kms_key.as_ref().unwrap())
+                    .unwrap()
+                    .as_bytes(false)
+                    .unwrap();
+            },
+            _ => (),
+        }
+
+        let pcr_signature = PcrSignature {
+            signing_certificate: self.signing_certificate.clone(),
+            signature,
+        };
+
+        self.write_signature(pcr_signature)
+            .expect("Failed to write signature to EIF.");
+
+        Ok(())
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -264,7 +264,7 @@ impl<T: Digest + Debug + Write + Clone> EifBuilder<T> {
     }
 
     fn kernel_size(&self) -> u64 {
-        self.kernel.metadata().unwrap().len() as u64
+        self.kernel.metadata().unwrap().len()
     }
 
     fn cmdline_offset(&self) -> u64 {
@@ -289,7 +289,7 @@ impl<T: Digest + Debug + Write + Clone> EifBuilder<T> {
     }
 
     fn ramdisk_size(&self, ramdisk: &File) -> u64 {
-        ramdisk.metadata().unwrap().len() as u64
+        ramdisk.metadata().unwrap().len()
     }
 
     fn signature_offset(&self) -> u64 {


### PR DESCRIPTION
*Issue #, if available:*
[aws/aws-nitro-enclaves-cli#204
](https://github.com/aws/aws-nitro-enclaves-cli/issues/204)
*Description of changes:*

- Added eif_signer.rs for signing existing enclave images.
- EifReader can now retrieve certificate information for images signed with KMS.
- PcrSignatureChecker can now be used to validate images signed with KMS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
