### PR TITLE
metadata: Enable built time override in metadata

### DIFF
--- a/src/utils/identity.rs
+++ b/src/utils/identity.rs
@@ -3,6 +3,7 @@
 
 use crate::defs::EifBuildInfo;
 use chrono::offset::Utc;
+use chrono::DateTime;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
@@ -17,8 +18,12 @@ pub fn generate_build_info(
     build_tool: &str,
     build_tool_version: &str,
     img_config_path: &str,
+    build_time_override: Option<DateTime<Utc>>,
 ) -> Result<EifBuildInfo, String> {
-    let now = Utc::now();
+    let now = match build_time_override {
+        Some(val) => val,
+        None => Utc::now(),
+    };
 
     let config_file = File::open(img_config_path)
         .map_err(|e| format!("Failed to open kernel image config file: {}", e))?;
@@ -50,6 +55,15 @@ macro_rules! generate_build_info {
             env!("CARGO_PKG_NAME"),
             env!("CARGO_PKG_VERSION"),
             $kernel_config_path,
+            None,
+        )
+    };
+    ($kernel_config_path:expr, $time_override:expr) => {
+        $crate::utils::identity::generate_build_info(
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+            $kernel_config_path,
+            $time_override,
         )
     };
 }


### PR DESCRIPTION
**Issue #, if available:** #21

**Description of changes:**

```
metadata: Enable built time override in metadata
    
With the built time being part of an EIF's metadata we are not able to
reproducibly build a byte-for-byte identical image file from the same
sources.
    
Allow to optionally provide a build time override as DateTime<Utc>.
Without providing a build time override the current time is taken as has
always been the case.
    
Signed-off-by: Leonard Foerster <foersleo@amazon.de>
```

**Testing done:**

I have built a aws-nitro-enclaves-cli with the dependencies pointing to the feature branch and some basic plumbing to expose the override functionality as a command line argument `override_time` (See https://github.com/foersleo/aws-nitro-enclaves-cli/commits/test_cli/).

With that CLI I built the hello example EIF in three scenarios, and checking the build time that ended up in the file:

```
// Without the new flag
$ nitro-cli build-enclave --docker-uri hello:latest --output-file hello_default.eif
[...]
$ nitro-cli describe-eif --eif-path hello_default.eif | grep BuildTime
    "BuildTime": "2024-06-13T15:18:38.606615052+00:00",

// With the new flag set to an arbitrary value
$ nitro-cli build-enclave --docker-uri hello:latest --output-file hello_time.eif --override_time "2022-02-02T02:02:02Z"
[...]
$ nitro-cli describe-eif --eif-path hello_time.eif | grep BuildTime
    "BuildTime": "2022-02-02T02:02:02+00:00",

// With a nonsense time string, which should result in `UNIX_EPOCH`
$ nitro-cli build-enclave --docker-uri hello:latest --output-file hello_garbage.eif --override_time foobar
[...]
$ nitro-cli describe-eif --eif-path hello_garbage.eif | grep BuildTime
    "BuildTime": "1970-01-01T00:00:00+00:00",
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
