### PR TITLE
rust: Catch up with more modern rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.58, stable, nightly]
+        rust: [1.68.2, stable, nightly]
     steps:
     - uses: actions/checkout@v3
     - run: rustup install ${{ matrix.rust }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "This library provides the definition of the enclave image format 
 repository = "https://github.com/aws/aws-nitro-enclaves-image-format"
 readme = "README.md"
 keywords = ["Nitro", "Enclaves", "AWS"]
-rust-version = "1.58"
+rust-version = "1.68"
 
 [dependencies]
 sha2 = "0.9.5"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [crates.io]: https://crates.io/crates/aws-nitro-enclaves-image-format
 [docs]: https://img.shields.io/docsrs/aws-nitro-enclaves-image-format
 [docs.rs]: https://docs.rs/aws-nitro-enclaves-image-format
-[msrv]: https://img.shields.io/badge/MSRV-1.58.1-blue
+[msrv]: https://img.shields.io/badge/MSRV-1.68.2-blue
 
 This library provides the definition of the enclave image format (EIF) file.
 

--- a/src/utils/eif_reader.rs
+++ b/src/utils/eif_reader.rs
@@ -242,7 +242,7 @@ impl EifReader {
 
         // Parse issuer into a BTreeMap
         let mut issuer_name = BTreeMap::new();
-        for (_, e) in cert.issuer_name().entries().enumerate() {
+        for e in cert.issuer_name().entries() {
             issuer_name.insert(
                 e.object().to_string(),
                 format!("{:?}", e.data()).replace(&['\"'][..], ""),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -682,8 +682,8 @@ impl PcrSignatureChecker {
                 let des_sign: Vec<PcrSignature> = from_slice(&buf[..])
                     .map_err(|e| format!("Error deserializing certificate: {:?}", e))?;
 
-                signing_certificate = des_sign[0].signing_certificate.clone();
-                signature = des_sign[0].signature.clone();
+                signing_certificate.clone_from(&des_sign[0].signing_certificate);
+                signature.clone_from(&des_sign[0].signature);
             }
 
             curr_seek += section.section_size as usize;


### PR DESCRIPTION
**Issue #, if available:** -

**Description of changes:**

To catch up with more recent rust this includes two parts:
* bump msrv to 1.68.2 (aligned with aws-nitro-enclaves-cli)
* Adhere to new clippy warnings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
