### PR TITLE
Update badge URL to reflect CI status correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![status]][actions] [![version]][crates.io] [![docs]][docs.rs] ![msrv]
 
-[status]: https://img.shields.io/github/workflow/status/aws/aws-nitro-enclaves-image-format/Rust/main
+[status]: https://img.shields.io/github/actions/workflow/status/aws/aws-nitro-enclaves-image-format/ci.yml?branch=main
 [actions]: https://github.com/aws/aws-nitro-enclaves-image-format/actions?query=branch%3Amain
 [version]: https://img.shields.io/crates/v/aws-nitro-enclaves-image-format.svg
 [crates.io]: https://crates.io/crates/aws-nitro-enclaves-image-format


### PR DESCRIPTION
*Description of changes:*
The current badge URL is not showing the accurate CI status. This commit updates the badge URL to properly display the CI status.

Relevant issue: https://github.com/badges/shields/issues/8671

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
