### PR TITLE
Add support to use KMS for signing EIF files when building them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup install ${{ matrix.rust }}
-    - run: cargo +${{ matrix.rust }} build --workspace
-    - run: cargo +${{ matrix.rust }} test --workspace
+    - run: cargo +${{ matrix.rust }} build --workspace --verbose
+    - run: |
+        cargo +${{ matrix.rust }} test --workspace --verbose \
+            -- --skip utils::tests::kms # Requires AWS creds
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.68.2, stable, nightly]
+        rust: [1.71.1, stable, nightly]
     steps:
     - uses: actions/checkout@v3
     - run: rustup install ${{ matrix.rust }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-nitro-enclaves-image-format"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ description = "This library provides the definition of the enclave image format 
 repository = "https://github.com/aws/aws-nitro-enclaves-image-format"
 readme = "README.md"
 keywords = ["Nitro", "Enclaves", "AWS"]
-rust-version = "1.68"
+rust-version = "1.71"
 
 [dependencies]
 sha2 = "0.9.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-nitro-enclaves-image-format"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,10 +20,21 @@ byteorder = "1.3"
 clap = "3.2"
 hex = "0.4"
 crc = "3.0"
-aws-nitro-enclaves-cose = "0.5"
+aws-nitro-enclaves-cose = { version = "0.5", features = ["key_kms"] }
 openssl = "0.10"
 serde_cbor = "0.11"
 chrono = { version = "0.4", default-features = false, features = ["clock"]}
+# These dependencies with versions less than specified are coming from
+# `aws-nitro-enclaves-cose` crate.
+aws-sdk-kms = "<=1.20"
+aws-config = "<=1.1"
+aws-types = "<=1.1"
+aws-smithy-runtime = { version = "<=1.2" }
+# Needed by `aws-nitro-enclaves-cose` to perform calls to KMS.
+tokio = { version = "1.20", features = ["rt-multi-thread"] }
+
+[dev-dependencies]
+tempfile = "3.5"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [crates.io]: https://crates.io/crates/aws-nitro-enclaves-image-format
 [docs]: https://img.shields.io/docsrs/aws-nitro-enclaves-image-format
 [docs.rs]: https://docs.rs/aws-nitro-enclaves-image-format
-[msrv]: https://img.shields.io/badge/MSRV-1.68.2-blue
+[msrv]: https://img.shields.io/badge/MSRV-1.71.1-blue
 
 This library provides the definition of the enclave image format (EIF) file.
 

--- a/eif_build/Cargo.toml
+++ b/eif_build/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["Nitro", "Enclaves", "AWS", "EIF"]
 rust-version = "1.68"
 
 [dependencies]
-aws-nitro-enclaves-image-format = { version = ">= 0.3.0" }
+aws-nitro-enclaves-image-format = "0.3"
 sha2 = "0.9.5"
 serde = { version = ">=1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/utils/identity.rs
+++ b/src/utils/identity.rs
@@ -9,7 +9,6 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 
 /// Utilities and helpers to fill EIF identity information
-
 const MAX_META_FILE_SIZE: u64 = 4096;
 const UNKNOWN_IMG_STR: &str = "Unknown";
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -66,7 +66,7 @@ pub struct SignKeyData {
 #[derive(Clone, Debug)]
 pub enum SignKeyInfo {
     // Local private key file path
-    LocalPrivateKeyInfo { path: String },
+    LocalPrivateKeyInfo { path: std::path::PathBuf },
 
     // KMS key details
     KmsKeyInfo { id: String, region: Option<String> },
@@ -76,7 +76,7 @@ pub enum SignKeyInfo {
 #[derive(Clone, Debug)]
 pub struct SignKeyDataInfo {
     // Path to the certificate file
-    pub cert_path: String,
+    pub cert_path: std::path::PathBuf,
 
     // Details of signing key itself
     pub key_info: SignKeyInfo,
@@ -841,9 +841,9 @@ mod tests {
         let cert_file_path = generate_certificate_file()?;
 
         let key_data = SignKeyData::new(&SignKeyDataInfo {
-            cert_path: cert_file_path.to_str().unwrap().to_string(),
+            cert_path: (&cert_file_path).into(),
             key_info: SignKeyInfo::LocalPrivateKeyInfo {
-                path: "/invalid/path".to_string(),
+                path: "/invalid/path".into(),
             },
         });
 
@@ -856,9 +856,9 @@ mod tests {
         let key_file_path = generate_pkey_file()?;
 
         let key_data = SignKeyData::new(&SignKeyDataInfo {
-            cert_path: "/invalid/path".to_string(),
+            cert_path: "/invalid/path".into(),
             key_info: SignKeyInfo::LocalPrivateKeyInfo {
-                path: key_file_path.to_str().unwrap().to_string(),
+                path: (&key_file_path).into(),
             },
         });
 
@@ -872,9 +872,9 @@ mod tests {
         let key_file_path = generate_pkey_file()?;
 
         let key_data = SignKeyData::new(&SignKeyDataInfo {
-            cert_path: cert_file_path.to_str().unwrap().to_string(),
+            cert_path: (&cert_file_path).into(),
             key_info: SignKeyInfo::LocalPrivateKeyInfo {
-                path: key_file_path.to_str().unwrap().to_string(),
+                path: (&key_file_path).into(),
             },
         })
         .unwrap();
@@ -900,7 +900,7 @@ mod tests {
             let key_region = env::var("AWS_KMS_TEST_KEY_REGION").ok();
 
             let key_data = SignKeyData::new(&SignKeyDataInfo {
-                cert_path: "/invalid/path".to_string(),
+                cert_path: "/invalid/path".into(),
                 key_info: SignKeyInfo::KmsKeyInfo {
                     id: key_id,
                     region: key_region,
@@ -922,7 +922,7 @@ mod tests {
             env::remove_var("AWS_REGION");
 
             let key_data = SignKeyData::new(&SignKeyDataInfo {
-                cert_path: cert_file_path.to_str().unwrap().to_string(),
+                cert_path: (&cert_file_path).into(),
                 key_info: SignKeyInfo::KmsKeyInfo {
                     id: key_id,
                     region: Some(key_region),
@@ -948,7 +948,7 @@ mod tests {
             env::set_var("AWS_REGION", key_region);
 
             let key_data = SignKeyData::new(&SignKeyDataInfo {
-                cert_path: cert_file_path.to_str().unwrap().to_string(),
+                cert_path: (&cert_file_path).into(),
                 key_info: SignKeyInfo::KmsKeyInfo {
                     id: key_id,
                     region: None,
@@ -971,7 +971,7 @@ mod tests {
             env::remove_var("AWS_REGION");
 
             let key_data = SignKeyData::new(&SignKeyDataInfo {
-                cert_path: cert_file_path.to_str().unwrap().to_string(),
+                cert_path: (&cert_file_path).into(),
                 key_info: SignKeyInfo::KmsKeyInfo {
                     id: key_id,
                     region: None,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -125,7 +125,7 @@ impl SignKeyData {
                     .await
                     .unwrap()
                 };
-                let runtime = Runtime::new().unwrap();
+                let runtime = Runtime::new().map_err(|e| e.to_string())?;
                 let key = runtime.block_on(act)?;
                 SignKey::KmsKey(key)
             }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-nitro-enclaves-cli/issues/204

*Description of changes:*

**This is a reworked version of https://github.com/aws/aws-nitro-enclaves-image-format/pull/20 because it needed to be rebased, and the repo has been split between the library and `eif_build` tool. This PR contains only the changes related to the library part**

We extend EIF building functionality with additional option of signing EIF files with KMS.
`sign_info` parameter of EifBuilder now turned to a structure that contains enum for the signing key.
This enum can be represented as local private key (previous functionality)
or KMS signing key (implemented in COSE library).

Also a couple of wrappers and helper methods are introduced
to store initial information about signing keys and transform it to the keys itself.

The information about KMS signing key is represented as unique KMS key id string and optional
region string. In case region is missed it will be read from `AWS_REGION` environment variable
as a standard way for SDK configuration.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
