### PR TITLE
Update eif_build tool

### DIFF
--- a/eif_build/Cargo.toml
+++ b/eif_build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eif_build"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ description = "This CLI tool provides a low level path to assemble an enclave im
 repository = "https://github.com/aws/aws-nitro-enclaves-image-format"
 readme = "README.md"
 keywords = ["Nitro", "Enclaves", "AWS", "EIF"]
-rust-version = "1.68"
+rust-version = "1.71"
 
 [dependencies]
 aws-nitro-enclaves-image-format = "0.4"

--- a/eif_build/Cargo.toml
+++ b/eif_build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eif_build"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["Nitro", "Enclaves", "AWS", "EIF"]
 rust-version = "1.68"
 
 [dependencies]
-aws-nitro-enclaves-image-format = "0.3"
+aws-nitro-enclaves-image-format = "0.4"
 sha2 = "0.9.5"
 serde = { version = ">=1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/eif_build/README.md
+++ b/eif_build/README.md
@@ -96,4 +96,7 @@ OPTIONS:
 
         --version <image_version>
             Version of the enclave image
+
+        --algo <(sha256|sha384|sha512)>
+            Sets algorithm to measure the image [default: sha384]
 ```

--- a/eif_build/README.md
+++ b/eif_build/README.md
@@ -82,6 +82,12 @@ OPTIONS:
         --private-key <private-key>
             Specify the path to the private-key
 
+        --kms-key-id <ID>
+            Specify ARN of a KMS key
+
+        --kms-key-region <REGION>
+            Region where the KMS key resides
+
         --ramdisk <FILE>
             Sets path to a ramdisk file representing a cpio.gz archive
 

--- a/eif_build/README.md
+++ b/eif_build/README.md
@@ -8,7 +8,7 @@
 [crates.io]: https://crates.io/crates/eif_build
 [docs]: https://img.shields.io/docsrs/eif_build
 [docs.rs]: https://docs.rs/eif_build
-[msrv]: https://img.shields.io/badge/MSRV-1.68.2-blue
+[msrv]: https://img.shields.io/badge/MSRV-1.71.1-blue
 
 This CLI tool provides a low level path to assemble an enclave image format (EIF) file used in AWS Nitro Enclaves.
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-nitro-enclaves-cli/issues/204
https://github.com/aws/aws-nitro-enclaves-image-format/issues/34

*Description of changes:*
**This is a updated version of #20  because it needed to be rebased and split between the library part and the binary tool**

We extend EIF building functionality with additional option of signing EIF files with KMS.
`sign_info` parameter of EifBuilder now turned to a structure that contains enum for the signing key.
This enum can be represented as local private key (previous functionality) or KMS signing key (implemented in COSE library).

This PR contains the following changes:
- Updates dependency `aws-nitro-enclaves-image-format` to 0.4.
- Bumps MSRV to 1.71 so the library and binary crates use the same Rust version.
- Updates `eif_build` with the new command line arguments:
  -  `kms-key-id`: ARN of the KMS key to be used to sign the EIF.
  - `kms-key-region`: region of the KMS key.
  - `algo`: algorithm to use for measurements, possible values: `sha256`, `sha384`, `sha512`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
