### PR TITLE
Sign from a Tokio context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-nitro-enclaves-image-format"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In order to allow signing with KMS keys, signing method must be called from inside a Tokio context. This commit updates method `EifBuilder::generate_pcr_signature` to handle signing in a Tokio task.

In order to be able to pass non-copiable KMS key into a Tokio context, we store KMS key objects using an atomic reference-counted smart pointer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
