### PR TITLE
Dispatch key type internally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws-nitro-enclaves-image-format"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -32,6 +32,7 @@ aws-types = "<=1.1"
 aws-smithy-runtime = { version = "<=1.2" }
 # Needed by `aws-nitro-enclaves-cose` to perform calls to KMS.
 tokio = { version = "1.20", features = ["rt-multi-thread"] }
+regex = "1.0"
 
 [dev-dependencies]
 tempfile = "3.5"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR removes the need to explicitly specify KMS key IDs. Instead, users can pass AWS KMS Key ARN instead of the local private key path, and the library selects the proper key type internally.

This change allows to remove parameters `--kms-key-id` and `--kms-key-region`. Instead, users will be able to specify ARNs (e.g. `--private-key arn:aws:kms:us-west-2:111122223333:key/0987dcba-abcd-4321-1234-ab0987654321`) and the library uses the proper internal representation, extracting key ID and region from the ARN.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
