### PR TITLE
Use private-key parameter for KMS keys

### DIFF
--- a/eif_build/Cargo.toml
+++ b/eif_build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eif_build"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The AWS Nitro Enclaves Team <aws-nitro-enclaves-devel@amazon.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["Nitro", "Enclaves", "AWS", "EIF"]
 rust-version = "1.71"
 
 [dependencies]
-aws-nitro-enclaves-image-format = "0.4"
+aws-nitro-enclaves-image-format = "0.5"
 sha2 = "0.9.5"
 serde = { version = ">=1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/eif_build/README.md
+++ b/eif_build/README.md
@@ -80,13 +80,7 @@ OPTIONS:
             Specify output file path
 
         --private-key <private-key>
-            Specify the path to the private-key
-
-        --kms-key-id <ID>
-            Specify ARN of a KMS key
-
-        --kms-key-region <REGION>
-            Region where the KMS key resides
+            Specify KMS key ARN, or the path to the local private key file
 
         --ramdisk <FILE>
             Sets path to a ramdisk file representing a cpio.gz archive

--- a/eif_build/src/main.rs
+++ b/eif_build/src/main.rs
@@ -18,10 +18,10 @@ use aws_nitro_enclaves_image_format::defs::{EifBuildInfo, EifIdentityInfo, EIF_H
 use aws_nitro_enclaves_image_format::utils::identity::parse_custom_metadata;
 use aws_nitro_enclaves_image_format::{
     generate_build_info,
-    utils::{get_pcrs, EifBuilder, SignKeyData, SignKeyDataInfo, SignKeyInfo},
+    utils::{get_pcrs, EifBuilder, SignKeyData},
 };
 use chrono::offset::Utc;
-use clap::{App, Arg, ArgGroup, ValueSource};
+use clap::{App, Arg, ValueSource};
 use serde_json::json;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::fmt::Debug;
@@ -93,32 +93,14 @@ fn main() {
                 .long("signing-certificate")
                 .help("Specify the path to the signing certificate")
                 .takes_value(true)
-                .requires("signing-key"),
+                .requires("private-key"),
         )
         .arg(
             Arg::with_name("private-key")
                 .long("private-key")
-                .help("Specify the path to the private-key")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("kms-key-id")
-                .long("kms-key-id")
-                .help("Specify unique id of the KMS key")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("kms-key-region")
-                .long("kms-key-region")
-                .help("Specify region in which the KMS key resides")
+                .help("Path to a local key or KMS key ARN")
                 .takes_value(true)
-                .requires("kms-key-id")
-        )
-        .group(
-            ArgGroup::new("signing-key")
-                .args(&["kms-key-id", "private-key"])
-                .multiple(false)
-                .requires("signing-certificate")
+                .requires("signing-certificate"),
         )
         .arg(
             Arg::with_name("image_name")
@@ -210,31 +192,18 @@ fn main() {
         .expect("Output file should be provided");
 
     let signing_certificate = matches.value_of("signing-certificate");
-
     let private_key = matches.value_of("private-key");
 
-    let kms_key_id = matches.value_of("kms-key-id");
-    let kms_key_region = matches.value_of("kms-key-region");
-
-    let sign_key_info = match (kms_key_id, private_key) {
-        (None, None) => None,
-        (Some(kms_id), None) => Some(SignKeyInfo::KmsKeyInfo {
-            id: kms_id.into(),
-            region: kms_key_region.map(str::to_string),
-        }),
-        (None, Some(key_path)) => Some(SignKeyInfo::LocalPrivateKeyInfo {
-            path: key_path.into(),
-        }),
-        _ => panic!("kms-key-id and private-key parameters are mutually exclusive"),
+    let sign_info = match (private_key, signing_certificate) {
+        (Some(key), Some(cert)) => SignKeyData::new(key, Path::new(&cert)).map_or_else(
+            |e| {
+                eprintln!("Could not read signing info: {:?}", e);
+                None
+            },
+            Some,
+        ),
+        _ => None,
     };
-
-    let sign_key_data = sign_key_info.map(|key_info| {
-        SignKeyData::new(&SignKeyDataInfo {
-            cert_path: signing_certificate.unwrap().into(),
-            key_info,
-        })
-        .expect("Could not read signing info")
-    });
 
     let img_name = matches.value_of("image_name").map(|val| val.to_string());
     let img_version = matches.value_of("image_name").map(|val| val.to_string());
@@ -329,7 +298,7 @@ fn main() {
         cmdline,
         ramdisks,
         output_path,
-        sign_info: sign_key_data,
+        sign_info,
         eif_info,
         arch,
     };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates `eif_build` tool to use `--private-key` for both KMS key ARNs and local private key files. Parameters `--kms-key-id` and `--kms-key-region` have been removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
