### PR TITLE
Update argument parsing logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ serde_json = "1.0"
 num-traits = "0.2"
 num-derive = "0.4"
 byteorder = "1.3"
-clap = "3.2"
 hex = "0.4"
 crc = "3.0"
 aws-nitro-enclaves-cose = { version = "0.5", features = ["key_kms"] }

--- a/eif_build/Cargo.toml
+++ b/eif_build/Cargo.toml
@@ -15,6 +15,6 @@ aws-nitro-enclaves-image-format = "0.5"
 sha2 = "0.9.5"
 serde = { version = ">=1.0", features = ["derive"] }
 serde_json = "1.0"
-clap = "3.2"
+clap = { version = "~4.4", features = ["derive", "string"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"]}
 

--- a/eif_build/src/main.rs
+++ b/eif_build/src/main.rs
@@ -21,13 +21,12 @@ use aws_nitro_enclaves_image_format::{
     utils::{get_pcrs, EifBuilder, SignKeyData},
 };
 use chrono::offset::Utc;
-use clap::{App, Arg, ValueSource};
+use clap::{App, Arg};
 use serde_json::json;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::fmt::Debug;
 use std::fs::OpenOptions;
 use std::io::Write;
-use ValueSource::CommandLine;
 
 pub struct EifBuildParameters<'a> {
     pub kernel_path: &'a str,
@@ -240,41 +239,6 @@ fn main() {
 
     if let Some(kernel_config) = matches.get_one::<String>("kernel_config") {
         build_info = generate_build_info!(kernel_config).expect("Can not generate build info");
-    }
-
-    if matches.value_source("build_time") == Some(CommandLine) {
-        build_info.build_time = matches
-            .get_one::<String>("build_time")
-            .expect("default value")
-            .to_string();
-    }
-
-    if matches.value_source("build_tool") == Some(CommandLine) {
-        build_info.build_tool = matches
-            .get_one::<String>("build_tool")
-            .expect("default_value")
-            .to_string();
-    }
-
-    if matches.value_source("build_tool_version") == Some(CommandLine) {
-        build_info.build_tool_version = matches
-            .get_one::<String>("build_tool_version")
-            .expect("default value")
-            .to_string();
-    }
-
-    if matches.value_source("img_os") == Some(CommandLine) {
-        build_info.img_os = matches
-            .get_one::<String>("img_os")
-            .expect("default value")
-            .to_string();
-    }
-
-    if matches.value_source("img_kernel") == Some(CommandLine) {
-        build_info.img_kernel = matches
-            .get_one::<String>("img_kernel")
-            .expect("default value")
-            .to_string();
     }
 
     let eif_info = EifIdentityInfo {


### PR DESCRIPTION
*Issue #, if available:* #44

*Description of changes:*

This PR updates the argument parsing logic:
- bumps clap from 3.2 to 4.4 (we cannot currently use 4.5 because it requires Rust > 1.71).
- remove duplicate arguments check
- removes unneeded dependency from clap in `image-format` library crate

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
