### PR TITLE
deps: Update sha2 from 0.9.5 to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["Nitro", "Enclaves", "AWS"]
 rust-version = "1.88"
 
 [dependencies]
-sha2 = "0.9.5"
+sha2 = "0.10"
 serde = { version = ">=1.0", features = ["derive"] }
 serde_json = "1.0"
 num-traits = "0.2"

--- a/src/defs/eif_hasher.rs
+++ b/src/defs/eif_hasher.rs
@@ -3,6 +3,7 @@
 
 #![deny(warnings)]
 
+use sha2::digest::FixedOutputReset;
 use sha2::Digest;
 use std::fmt::Debug;
 use std::io::Result as IoResult;
@@ -22,7 +23,7 @@ use serde::{Deserialize, Serialize};
 /// 3. digest = Hash(Concatenate(digest, block))
 /// 4. Goto step 2
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EifHasher<T: Digest + Debug + Write + Clone> {
+pub struct EifHasher<T: Digest + FixedOutputReset + Debug + Write + Clone> {
     /// The bytes that have not been hashed yet, they get hashed
     /// once we gather block_size bytes.
     pub block: Vec<u8>,
@@ -44,7 +45,7 @@ fn initial_digest(len: usize) -> Vec<u8> {
     vec![0; len]
 }
 
-impl<T: Digest + Debug + Write + Clone> EifHasher<T> {
+impl<T: Digest + FixedOutputReset + Debug + Write + Clone> EifHasher<T> {
     pub fn new(block_size: usize, mut hasher: T) -> Result<Self, String> {
         let output_size = hasher.finalize_reset().len();
         if block_size > 0 && output_size * 2 > block_size {
@@ -113,7 +114,7 @@ impl<T: Digest + Debug + Write + Clone> EifHasher<T> {
     }
 }
 
-impl<T: Digest + Debug + Write + Clone> Write for EifHasher<T> {
+impl<T: Digest + FixedOutputReset + Debug + Write + Clone> Write for EifHasher<T> {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
         if self.block_size == 0 {
             self.hasher.write_all(buf)?;
@@ -140,6 +141,7 @@ impl<T: Digest + Debug + Write + Clone> Write for EifHasher<T> {
 #[cfg(test)]
 mod tests {
     use super::{initial_digest, EifHasher};
+    use sha2::digest::FixedOutputReset;
     use sha2::{Digest, Sha256, Sha384, Sha512};
     use std::fmt::Debug;
     use std::io::Write;
@@ -167,7 +169,7 @@ mod tests {
         hash_less_values_than_block_size(Sha384::new(), INPUT_BLOCK_SIZE_SHA384);
     }
 
-    fn hash_less_values_than_block_size<T: Digest + Debug + Write + Clone>(
+    fn hash_less_values_than_block_size<T: Digest + FixedOutputReset + Debug + Write + Clone>(
         mut hasher_alg: T,
         block_size: usize,
     ) {
@@ -207,7 +209,7 @@ mod tests {
         hash_exact_block_size_values(Sha512::new(), INPUT_BLOCK_SIZE_SHA512);
     }
 
-    fn hash_exact_block_size_values<T: Digest + Debug + Write + Clone>(
+    fn hash_exact_block_size_values<T: Digest + FixedOutputReset + Debug + Write + Clone>(
         mut hasher_alg: T,
         block_size: usize,
     ) {
@@ -248,7 +250,7 @@ mod tests {
         hash_more_values_than_block_size(Sha512::new(), INPUT_BLOCK_SIZE_SHA512);
     }
 
-    fn hash_more_values_than_block_size<T: Digest + Debug + Write + Clone>(
+    fn hash_more_values_than_block_size<T: Digest + FixedOutputReset + Debug + Write + Clone>(
         mut hasher_alg: T,
         block_size: usize,
     ) {
@@ -292,7 +294,7 @@ mod tests {
         hash_with_writes_of_different_sizes(Sha512::new(), INPUT_BLOCK_SIZE_SHA512);
     }
 
-    fn hash_with_writes_of_different_sizes<T: Digest + Debug + Write + Clone>(
+    fn hash_with_writes_of_different_sizes<T: Digest + FixedOutputReset + Debug + Write + Clone>(
         hasher_alg: T,
         block_size: usize,
     ) {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,6 +15,7 @@ use crc::{Crc, CRC_32_ISO_HDLC};
 use openssl::asn1::Asn1Time;
 use serde::{Deserialize, Serialize};
 use serde_cbor::from_slice;
+use sha2::digest::FixedOutputReset;
 use sha2::Digest;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -41,7 +42,7 @@ use std::path::Path;
 const DEFAULT_SECTIONS_COUNT: u16 = 3;
 
 /// Utility function to calculate PCRs, used at build and describe.
-pub fn get_pcrs<T: Digest + Debug + Write + Clone>(
+pub fn get_pcrs<T: Digest + FixedOutputReset + Debug + Write + Clone>(
     image_hasher: &mut EifHasher<T>,
     bootstrap_hasher: &mut EifHasher<T>,
     app_hasher: &mut EifHasher<T>,
@@ -88,7 +89,7 @@ pub fn get_pcrs<T: Digest + Debug + Write + Clone>(
     Ok(measurements)
 }
 
-pub struct EifBuilder<T: Digest + Debug + Write + Clone> {
+pub struct EifBuilder<T: Digest + FixedOutputReset + Debug + Write + Clone> {
     kernel: File,
     cmdline: Vec<u8>,
     ramdisks: Vec<File>,
@@ -112,7 +113,7 @@ pub struct EifBuilder<T: Digest + Debug + Write + Clone> {
     eif_crc: u32,
 }
 
-impl<T: Digest + Debug + Write + Clone> EifBuilder<T> {
+impl<T: Digest + FixedOutputReset + Debug + Write + Clone> EifBuilder<T> {
     pub fn new(
         kernel_path: &Path,
         cmdline: String,


### PR DESCRIPTION
Update sha2 dependency to version 0.10 which includes performance improvements and security updates from the RustCrypto team.

The sha2 0.10 API requires the FixedOutputReset trait bound for finalize_reset() method, so all generic type bounds using Digest have been updated to include this additional trait constraint.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
