### PR TITLE
Update Rust version to 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [1.83, stable, nightly]
+        rust: [1.88, stable, nightly]
     steps:
     - uses: actions/checkout@v3
     - run: rustup install ${{ matrix.rust }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "This library provides the definition of the enclave image format 
 repository = "https://github.com/aws/aws-nitro-enclaves-image-format"
 readme = "README.md"
 keywords = ["Nitro", "Enclaves", "AWS"]
-rust-version = "1.83"
+rust-version = "1.88"
 
 [dependencies]
 sha2 = "0.9.5"

--- a/eif_build/Cargo.toml
+++ b/eif_build/Cargo.toml
@@ -8,7 +8,7 @@ description = "This CLI tool provides a low level path to assemble an enclave im
 repository = "https://github.com/aws/aws-nitro-enclaves-image-format"
 readme = "README.md"
 keywords = ["Nitro", "Enclaves", "AWS", "EIF"]
-rust-version = "1.83"
+rust-version = "1.88"
 
 [dependencies]
 aws-nitro-enclaves-image-format = "0.5"


### PR DESCRIPTION
Some updated dependencies want a newer Rust version. Bump it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
