### PR TITLE
fix: read image_version CLI arg instead of image_name for img_version

### DIFF
--- a/eif_build/src/main.rs
+++ b/eif_build/src/main.rs
@@ -189,7 +189,7 @@ fn main() {
     };
 
     let img_name = matches.get_one::<String>("image_name").map(String::from);
-    let img_version = matches.get_one::<String>("image_name").map(String::from);
+    let img_version = matches.get_one::<String>("image_version").map(String::from);
     let metadata_path = matches.get_one::<String>("metadata").map(String::from);
     let metadata = match metadata_path {
         Some(ref path) => {


### PR DESCRIPTION
## Summary

`eif_build/src/main.rs` line 192 reads the `image_name` CLI argument a second time instead of `image_version`, causing the `--version` flag to be silently ignored. The EIF metadata `ImageVersion` field always receives either the image name or the default `"1.0"`.

## Bug

```rust
// Line 191 (correct):
let img_name = matches.get_one::<String>("image_name").map(String::from);
// Line 192 (bug — copy-paste from line above):
let img_version = matches.get_one::<String>("image_name").map(String::from);
```

`img_version` is used at line 238 to populate `EifIdentityInfo`, so the version metadata is always wrong when `--version` differs from `--name`.

## Minimal repro

```bash
eif_build --kernel bzImage --ramdisk rootfs.cpio \
          --output test.eif \
          --name "my-enclave" --version "2.3.4"
```

**Before fix:** `EifIdentityInfo.img_version` = `"my-enclave"` (copies `--name`)
**After fix:** `EifIdentityInfo.img_version` = `"2.3.4"` (reads `--version` correctly)

If `--name` is omitted, `img_version` falls through to the default `"1.0"` regardless of `--version`.

## Fix

One-line change: `"image_name"` → `"image_version"` on line 192.

## Testing

- `eif_build` has no CLI argument parsing tests (all existing tests are in the library crate under `src/defs/` and `src/utils/`)
- Verified manually: after the fix, `matches.get_one::<String>("image_version")` reads the correct clap `Arg::new("image_version").long("version")` argument defined at line 102, and the value flows into `EifIdentityInfo.img_version` at line 238
- The bug predates the clap 4 migration — the same copy-paste error existed in the earlier clap 3 code