### PR TITLE
Remove broken doc string that blocks rustdoc.

### DIFF
--- a/src/utils/eif_signer.rs
+++ b/src/utils/eif_signer.rs
@@ -192,7 +192,6 @@ impl EifSigner {
     }
 
     /// Generate the signature of the EIF.
-    /// eif_signature = [pcr0_signature]
     pub fn generate_eif_signature(
         &self,
         measurements: &BTreeMap<String, String>,


### PR DESCRIPTION
The `[…]` in

```rs
/// eif_signature = [pcr0_signature]
```

is interpreted as a link, but `pcr0_signature` does not resolve. This blocks the generation of documentation.

---

This does appear in
- https://docs.rs/aws-nitro-enclaves-image-format/0.6.0/aws_nitro_enclaves_image_format/utils/eif_signer/struct.EifSigner.html#method.generate_eif_signature

but I assume the square brackets were escaped to fix, but the change was not committed?

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
