### PR TITLE
fix: Update arn parsing regex to allow any aws partitions

### DIFF
--- a/src/utils/eif_signer.rs
+++ b/src/utils/eif_signer.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::mem::size_of;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tokio::runtime::Runtime;
 
 // Signing key for eif images
@@ -51,19 +51,20 @@ impl SignKeyInfo {
     }
 }
 
-fn parse_kms_arn(s: &str) -> Option<String> {
-    // Matches KMS key ARNs in the format:
-    // arn:partition:kms:region:account-id:key[/|:]key-id where:
-    // - partition is: aws, aws-cn, or aws-us-gov
-    // - region is captured: letters, numbers, hyphens
-    // - account-id: exactly 12 digits
-    // - key-id is captured: letters, numbers, hyphens
-    let re = Regex::new(
-        r"^arn:(?:aws|aws-cn|aws-us-gov):kms:([a-z0-9-]+):\d{12}:key[:/]([a-zA-Z0-9-]+)$",
-    )
-    .expect("Regular expression for parsing ARNs must be valid");
+// Matches KMS key ARNs in the format:
+// arn:partition:kms:region:account-id:key[/|:]key-id where:
+// - partition is: aws prefixed string
+// - region is captured: letters, numbers, hyphens
+// - account-id: exactly 12 digits
+// - key-id: letters, numbers, hyphens
+// Compiled once on first use instead of on every `parse_kms_arn` call.
+static KMS_ARN_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^arn:aws(?:[\-a-z]+)?:kms:([a-z0-9-]+):\d{12}:key[:/][a-zA-Z0-9-]+$")
+        .expect("Regular expression for parsing ARNs must be valid")
+});
 
-    re.captures(s).map(|caps| {
+fn parse_kms_arn(s: &str) -> Option<String> {
+    KMS_ARN_REGEX.captures(s).map(|caps| {
         // Safe to use index access since we know the pattern has exactly 2 capture groups
         caps[1].to_string()
     })


### PR DESCRIPTION
*Description of changes:*

    `parse_kms_arn` should not be deciding whether the partition is valid or
    not, since this is already implicitly done by the KMS client when
    fetching the KMS key. If the ARN is not valid, the key fetch will
    fail. Allow any string prefixed with `aws`, which is sufficient to match
    all partitions.

    Also remove unecessary capturing groups no longer used.

# Testing done

Tested at https://regex101.com/?regex=%5Earn%3Aaws%28%3F%3A%5B%5C-a-z%5D%2B%29%3F%3Akms%3A%28%5Ba-z0-9-%5D%2B%29%3A%5Cd%7B12%7D%3Akey%5B%3A%5C%2F%5D%5Ba-zA-Z0-9-%5D%2B%24&testString=arn%3Aaws-hello-world%3Akms%3Acn-north-1%3A123456789012%3Akey%2Fabcd1234&flags=gm&flavor=pcre2&delimiter=%2F

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
