### PR TITLE
eif_build: build against the 0.6 library and sha2 0.10

### DIFF
--- a/eif_build/Cargo.toml
+++ b/eif_build/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["Nitro", "Enclaves", "AWS", "EIF"]
 rust-version = "1.94.1"
 
 [dependencies]
-aws-nitro-enclaves-image-format = "0.5"
-sha2 = "0.9.5"
+aws-nitro-enclaves-image-format = "0.6"
+sha2 = "0.10"
 serde = { version = ">=1.0", features = ["derive"] }
 serde_json = "1.0"
 clap = { version = "~4.4", features = ["derive", "string"] }

--- a/eif_build/src/main.rs
+++ b/eif_build/src/main.rs
@@ -23,6 +23,7 @@ use aws_nitro_enclaves_image_format::{
 use chrono::offset::Utc;
 use clap::{Arg, ArgAction, Command};
 use serde_json::json;
+use sha2::digest::FixedOutputReset;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::fmt::Debug;
 use std::fs::OpenOptions;
@@ -262,7 +263,10 @@ fn main() {
     }
 }
 
-pub fn build_eif<T: Digest + Debug + Write + Clone>(params: EifBuildParameters, hasher: T) {
+pub fn build_eif<T: Digest + FixedOutputReset + Debug + Write + Clone>(
+    params: EifBuildParameters,
+    hasher: T,
+) {
     let mut output_file = OpenOptions::new()
         .read(true)
         .create(true)


### PR DESCRIPTION
*Description of changes:*

The 0.6 library bumped sha2 to 0.10, whose Digest split out the FixedOutputReset trait. EifBuilder / get_pcrs / EifHasher now require T: Digest + FixedOutputReset + ..., and the EifHasher reset path needs the 0.10 API, so eif_build must move in lockstep:

- bump its aws-nitro-enclaves-image-format dependency 0.5 -> 0.6 and sha2 0.9.5 -> 0.10 so the whole workspace resolves a single digest version
- add the FixedOutputReset bound to build_eif's generic hasher parameter to match the library's EifBuilder/get_pcrs bounds

Original-author: Marius Knaust <mknaust@amazon.de>
Signed-off-by: Michael Wink <winkmw@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
