### PR TITLE
Unpack GetPublicKey errors when fetching KMS key

### DIFF
--- a/src/utils/eif_signer.rs
+++ b/src/utils/eif_signer.rs
@@ -2,10 +2,12 @@ use crate::defs::{EifHeader, EifSectionHeader, EifSectionType, PcrInfo, PcrSigna
 use crate::utils::eif_reader::EifReader;
 use crate::utils::get_pcrs;
 use aws_config::BehaviorVersion;
+use aws_nitro_enclaves_cose::error::CoseError;
 use aws_nitro_enclaves_cose::{
     crypto::kms::KmsKey, crypto::Openssl, header_map::HeaderMap, CoseSign1,
 };
 use aws_sdk_kms::client::Client;
+use aws_sdk_kms::error::ProvideErrorMetadata;
 use aws_types::region::Region;
 use openssl::pkey::PKey;
 use regex::Regex;
@@ -118,8 +120,17 @@ impl SignKeyData {
                     let arn_copy = arn.clone();
                     tokio::task::spawn_blocking(move || {
                         let client = Client::new(&sdk_config);
-                        KmsKey::new_with_public_key(client, arn_copy, None)
-                            .map_err(|e| e.to_string())
+                        KmsKey::new_with_public_key(client, arn_copy, None).map_err(|e| {
+                            if let CoseError::AwsGetPublicKeyError(sdk) = &e {
+                                format!(
+                                    "KMS GetPublicKey failed: {}: {}",
+                                    sdk.code().unwrap_or("Unknown"),
+                                    sdk.message().unwrap_or("no message")
+                                )
+                            } else {
+                                e.to_string()
+                            }
+                        })
                     })
                     .await
                     .unwrap()


### PR DESCRIPTION
*Description of changes:*

Previously the KMS client errors would not fully propagate up to the CLI, instead just printing a generic "service error", for example:
```
Could not read signing info: "AWS GetPublicKey error: service error"
```

This commit changes the error parsing to attempt to unpack the actual KMS service errors and have them propagated up the chain. Example:
```
Could not read signing info: "KMS GetPublicKey failed:
AccessDeniedException: ...
```

*Issue #, if available:* https://github.com/aws/aws-nitro-enclaves-cli/issues/756

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
